### PR TITLE
isEthernet() - ARPHRD_PPP does not require ethernet headers

### DIFF
--- a/Tethering/jni/com_android_networkstack_tethering_BpfUtils.cpp
+++ b/Tethering/jni/com_android_networkstack_tethering_BpfUtils.cpp
@@ -178,6 +178,7 @@ static jboolean com_android_networkstack_tethering_BpfUtils_isEthernet(JNIEnv* e
         case ARPHRD_ETHER:
             return true;
         case ARPHRD_NONE:
+        case ARPHRD_PPP:
         case ARPHRD_RAWIP:  // in Linux 4.14+ rmnet support was upstreamed and this is 519
         case 530:           // this is ARPHRD_RAWIP on some Android 4.9 kernels with rmnet
             return false;


### PR DESCRIPTION
(this is required to make ipv6 tethering work with at least S.LSI modems)

Test: TreeHugger
Bug: 207057951
Signed-off-by: Maciej Żenczykowski <maze@google.com>
Change-Id: Ic178db928ec7f74f69d7d4739b3b8439ff026625